### PR TITLE
AddAdd HyprlandDataWithArgument trait to Monitors

### DIFF
--- a/src/ctl/data/data_models.rs
+++ b/src/ctl/data/data_models.rs
@@ -84,7 +84,7 @@ pub struct Monitor {
     pub available_modes: Vec<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug, HyprlandData)]
+#[derive(Serialize, Deserialize, Debug, HyprlandData, HyprlandDataWithArgument)]
 pub struct Monitors(Vec<Monitor>);
 auto_deref!(Monitors = Vec<Monitor>);
 

--- a/src/ctl/data/mod.rs
+++ b/src/ctl/data/mod.rs
@@ -83,6 +83,9 @@ mod data_tests {
 
         assert!(conn.get_sync::<Version>().is_ok());
         assert!(conn.get_sync::<Monitors>().is_ok());
+        assert!(conn
+            .get_with_argument_sync::<Monitors>("all".to_string())
+            .is_ok());
         assert!(conn.get_sync::<Workspace>().is_ok());
         assert!(conn.get_sync::<Workspaces>().is_ok());
         assert!(conn.get_sync::<WorkspaceRules>().is_ok());


### PR DESCRIPTION
`get::<Monitors>` only gets data on enabled monitors. In order to get all monitors, the "all" argument has to be passed.